### PR TITLE
fix: Update QueryLogRepository to filter by 'CALCULATE' type for user…

### DIFF
--- a/backend/src/main/java/com/smu/tariff/logging/QueryLogRepository.java
+++ b/backend/src/main/java/com/smu/tariff/logging/QueryLogRepository.java
@@ -1,20 +1,22 @@
 package com.smu.tariff.logging;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import java.util.List;
 
 public interface QueryLogRepository extends JpaRepository<QueryLog, Long> {
     // Fetch logs with their associated user to avoid LazyInitializationException when accessed outside a transaction
     @Query("select q from QueryLog q left join fetch q.user order by q.createdAt desc")
     List<QueryLog> findAllWithUser();
 
-    @Query("select q from QueryLog q left join fetch q.user where q.user.id = :userId order by q.createdAt desc")
+    @Query("select q from QueryLog q left join fetch q.user where q.user.id = :userId and q.type = 'CALCULATE' order by q.createdAt desc")
     List<QueryLog> findByUserIdWithUser(@Param("userId") Long userId);
 
-    @Query(value = "select q.id, q.created_at, q.user_id from query_log q where q.user_id = :userId order by q.created_at desc limit 50", nativeQuery = true)
+    @Query(value = "select q.id, q.created_at, q.user_id from query_log q where q.user_id = :userId and q.type = 'CALCULATE' order by q.created_at desc limit 50", nativeQuery = true)
     List<Object[]> findLatestRawByUser(@Param("userId") Long userId);
 
-    long countByUser_Id(Long userId);
+    @Query("select count(q) from QueryLog q where q.user.id = :userId and q.type = 'CALCULATE'")
+    long countByUser_Id(@Param("userId") Long userId);
 }


### PR DESCRIPTION
This pull request refines the queries in the `QueryLogRepository` to ensure that only logs of type `'CALCULATE'` are returned or counted when filtering by user. This helps prevent returning or counting irrelevant log entries and makes the repository methods more precise.

**Improvements to query filtering:**

* Updated the JPQL query in `findByUserIdWithUser` to filter logs by both `userId` and `type = 'CALCULATE'`, ensuring only calculation logs are returned for a given user.
* Modified the native SQL query in `findLatestRawByUser` to include `type = 'CALCULATE'` in the filter, so only calculation logs are retrieved for the latest 50 entries.
* Changed the `countByUser_Id` method to use a JPQL query that counts only logs of type `'CALCULATE'` for a given user, rather than all logs.…-specific queries